### PR TITLE
Making the events hash protected in Socket class

### DIFF
--- a/src/main/java/com/github/nkzawa/socketio/client/Socket.java
+++ b/src/main/java/com/github/nkzawa/socketio/client/Socket.java
@@ -55,7 +55,7 @@ public class Socket extends Emitter {
 
     public static final String EVENT_RECONNECTING = Manager.EVENT_RECONNECTING;
 
-    private static Map<String, Integer> events = new HashMap<String, Integer>() {{
+    protected static Map<String, Integer> events = new HashMap<String, Integer>() {{
         put(EVENT_CONNECT, 1);
         put(EVENT_CONNECT_ERROR, 1);
         put(EVENT_CONNECT_TIMEOUT, 1);


### PR DESCRIPTION
I need the `events` hash to be protected so I can extend the Socket class and change it's values.
Since the `emit` method uses this hash to check if the event it also needs to be emitted locally.

The whole idea of this is to write a mockserver to test the sockets, like [this one](https://github.com/icapurro/socket.io-client.java/tree/mockserver/src/main/java/com/github/nkzawa/socketio/mockserver)